### PR TITLE
Place fields used in atomic operations at beginning of struct

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -95,6 +95,10 @@ type contextItem struct {
 // context, cause, and metadata like code and category. It is thread-safe and
 // supports pooling for performance.
 type Error struct {
+	// Fields used in atomic operations. Place them at the beginning of the
+	// struct to ensure proper alignment across all architectures.
+	count uint64 // Occurrence count for tracking frequency.
+
 	// Primary fields (frequently accessed).
 	msg   string    // The error message displayed by Error().
 	name  string    // The error name or type (e.g., "AuthError").
@@ -103,7 +107,6 @@ type Error struct {
 	// Secondary metadata.
 	template   string // Fallback message template if msg is empty.
 	category   string // Error category (e.g., "network").
-	count      uint64 // Occurrence count for tracking frequency.
 	code       int32  // HTTP-like status code (e.g., 400, 500).
 	smallCount int32  // Number of items in smallContext.
 


### PR DESCRIPTION
Recently this library was packaged for use in Debian. On 32bit architectures, such as armhf, there's a panic when running tests:

```
--- FAIL: TestErrorMethods (0.00s)
panic: unaligned 64-bit atomic operation [recovered]
	panic: unaligned 64-bit atomic operation

goroutine 100 [running]:
testing.tRunner.func1.2({0x1e2a20, 0x250a90})
	/usr/lib/go-1.24/src/testing/testing.go:1734 +0x254
testing.tRunner.func1()
	/usr/lib/go-1.24/src/testing/testing.go:1737 +0x3d4
panic({0x1e2a20, 0x250a90})
	/usr/lib/go-1.24/src/runtime/panic.go:792 +0xfc
internal/runtime/atomic.panicUnaligned()
	/usr/lib/go-1.24/src/internal/runtime/atomic/unaligned.go:8 +0x24
internal/runtime/atomic.Xadd64(0xd292c4, 0x1)
	/usr/lib/go-1.24/src/internal/runtime/atomic/atomic_arm.s:318 +0x14
github.com/olekukonko/errors.(*Error).Increment(...)
	/tmp/autopkgtest-lxc.jaml3hhb/downtmp/autopkgtest_tmp/_build/src/github.com/olekukonko/errors/errors.go:914
github.com/olekukonko/errors.TestErrorMethods(0xdb4fc8)
	/tmp/autopkgtest-lxc.jaml3hhb/downtmp/autopkgtest_tmp/_build/src/github.com/olekukonko/errors/errors_test.go:126 +0x5e4
testing.tRunner(0xdb4fc8, 0x219920)
	/usr/lib/go-1.24/src/testing/testing.go:1792 +0x124
created by testing.(*T).Run in goroutine 1
	/usr/lib/go-1.24/src/testing/testing.go:1851 +0x448
FAIL	github.com/olekukonko/errors	0.101s
```

The fix is easy -- move the field used in the atomic operations to the beginning of the struct which will ensure proper alignment across all architectures.